### PR TITLE
mondrian: overlay: drop smooth display and use min/max refresh rate

### DIFF
--- a/overlay/Settings/res/values/config.xml
+++ b/overlay/Settings/res/values/config.xml
@@ -4,6 +4,9 @@
      SPDX-License-Identifier: Apache-2.0
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- Whether to show Smooth Display feature in Settings Options -->
-    <bool name="config_show_smooth_display">true</bool>
+ <bool name="config_show_smooth_display">false</bool>
+
+    <!-- Whether to show min/max refresh rate in display settings -->
+    <bool name="config_show_refresh_rate_controls">true</bool>
+    <bool name="config_supports_dynamic_refresh_rate_controls">true</bool>
 </resources>


### PR DESCRIPTION
* smooth display can have some issue so we can use the min/max toogles